### PR TITLE
screenshot: Remove runtime dependency on emprint (#26)

### DIFF
--- a/screenshot/configure.ac
+++ b/screenshot/configure.ac
@@ -62,11 +62,6 @@ AC_SUBST(EDJE_CC)
 AC_MSG_CHECKING([Which edje_cc to use])
 AC_MSG_RESULT(${EDJE_CC})
 
-AC_PATH_PROG(EMPRINT, "emprint", "", $PATH)
-if test "$EMPRINT" = ""; then
-  AC_MSG_ERROR(emprint not found)
-fi
-
 datadir=$(pkg-config --variable=modules enlightenment)/${PACKAGE}
 AC_ARG_ENABLE(homedir-install,
   AS_HELP_STRING([--enable-homedir-install], [Install module in homedir]),


### PR DESCRIPTION
This makes building the whole `moksha-modules-extra` at once possible.